### PR TITLE
Create the client once instead of for each event

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,8 +61,8 @@ func prettyPrintStruct(item interface{}) string {
 
 func startWatchdog(config types.Configuration) {
 	healthChan := make(chan types.StatsEvent)
-	client := getTelemetryClient(config)
-	
+	client := newTelemetryClient(config)
+
 	go routing.StartCheck(config, healthChan)
 	go health.StartCheck(config, healthChan)
 


### PR DESCRIPTION
Pulled the client creation and initialization in its own function.
⚠️ I have not tested the actual consequences of adding variables to the context. 

[AppInsights Data model documentation](https://docs.microsoft.com/en-us/azure/application-insights/application-insights-data-model-context) 
[TelemetryContext go implementation](https://github.com/Microsoft/ApplicationInsights-Go/blob/master/appinsights/telemetrycontext.go)