### PR TITLE
Added explicit time unit to request duration

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,9 +69,8 @@ func startWatchdog(config types.Configuration) {
 		event := <-healthChan
 		publishToAppInsights(event, config)
 		if config.Debug {
-
+			fmt.Println(prettyPrintStruct(event))
 		}
-		fmt.Println(prettyPrintStruct(event))
 	}
 }
 
@@ -82,7 +81,7 @@ func publishToAppInsights(event types.StatsEvent, config types.Configuration) {
 	telemetry.SetProperty("source", event.Source)
 	telemetry.SetProperty("instanceID", config.InstanceID) //Duplicated for discoverability
 	telemetry.SetProperty("isSuccess", strconv.FormatBool(event.IsSuccess))
-	telemetry.SetProperty("requestDuration", event.RequestDuration.String())
+	telemetry.SetProperty("requestDurationInNs", strconv.FormatInt(event.RequestDuration.Nanoseconds(), 10))
 	if !event.IsSuccess {
 		telemetry.SetProperty("errorDetails", event.ErrorDetails)
 	}


### PR DESCRIPTION
Address issue #8 

Adds explicit time unit to RequestDuration AppInsights telemetry event.
This introduces a slight diff between the event printed to stdout when debug is enabled vs what will be stored in ApplicationInsights. The Telemetry Event doesn't have json tags so does not marshal correctly - a work around would be needed. For now, we accept the slight difference in events.