### PR TITLE
Added static checking and testing to docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+
+language: go
+
+services:
+  - docker
+
+before_install:
+  - docker build -t lawrencegripper/traefik-appinsights-watchdog .

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@ sudo: required
 
 language: go
 
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 services:
   - docker
 
-before_install:
-  - docker build -t lawrencegripper/traefik-appinsights-watchdog .
+script:
+  - bash ./build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN dep ensure --vendor-only -v
 
 COPY . /go/src/github.com/lawrencegripper/traefik-appinsights-watchdog/
 
-RUN chmod +x codechecks.sh && ./codechecks.sh
+RUN chmod +x codechecks.sh; sync; ./codechecks.sh
 
 RUN go build -o traefik-appinsights-watchdog -v
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,26 @@
 # build stage
-FROM ataraev/golang-alpine-git AS build-env
+FROM golang:1.9.2-alpine AS build-env
 ENV GOBIN /go/bin
-RUN apk add --update openssl && \ 
-    wget -O /go/bin/dep http://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 && \
-    chmod +x /go/bin/dep
+RUN apk add --update --no-progress openssl git wget bash gcc musl-dev && \ 
+    rm -rf /var/cache/apk/* && \
+    wget --quiet -O /go/bin/dep https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 && \
+    chmod +x /go/bin/dep && \
+    go get github.com/golang/lint/golint && \
+    go get -u honnef.co/go/tools/cmd/...
+
 
 COPY ./Gopkg.* /go/src/github.com/lawrencegripper/traefik-appinsights-watchdog/
 WORKDIR /go/src/github.com/lawrencegripper/traefik-appinsights-watchdog
 RUN dep ensure --vendor-only -v
 
 COPY . /go/src/github.com/lawrencegripper/traefik-appinsights-watchdog/
+
+RUN chmod +x codechecks.sh && ./codechecks.sh
+
 RUN go build -o traefik-appinsights-watchdog -v
 
 # final stage
-FROM golang:alpine
+FROM alpine
 WORKDIR /app
 COPY --from=build-env /go/src/github.com/lawrencegripper/traefik-appinsights-watchdog/traefik-appinsights-watchdog .
 ENTRYPOINT ["./traefik-appinsights-watchdog"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Traefik Application Insights Watchdog
 =============
 
+[![Build Status](https://travis-ci.org/lawrencegripper/traefik-appinsights-watchdog.svg?branch=master)](https://travis-ci.org/lawrencegripper/traefik-appinsights-watchdog)
+
 > *Please note*: This project is in development. The current readme is a draft. 
 
 ## What is it?

--- a/README.md
+++ b/README.md
@@ -115,3 +115,9 @@ However, it can be run independently inside other orchestrator's such a Kubernet
 This project is a simple watchdog service provided 'as is' and we currently have no plans to expands it's feature set.
 
 We would welcome contributions. If you identify issues please log them and, if possible, develop a fix in as a PR.
+
+## Building
+
+Run `build.sh` this has a dependency on docker.
+
+The build with run a set of checks, execute tests and then output. Once completed you can use `docker run --rm traefik-appinsights-watchdog:latest --appinsightskey=XXXXXXXXX --debug` to test your build.

--- a/codechecks.sh
+++ b/codechecks.sh
@@ -1,0 +1,21 @@
+
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+PKGS=$(go list ./... | grep -v '/vendor/') 
+GOFILES=$(go list -f '{{range $index, $element := .GoFiles}}{{$.Dir}}/{{$element}}{{"\n"}}{{end}}' ./... | grep -v '/vendor/') 
+echo "----------> Running gofmt"
+unformatted=$(gofmt -l $GOFILES)
+if [ ! -z "$unformatted" ]; then
+  echo "needs formatting: $unformatted"
+  exit 1
+fi
+echo "----------> Running golint" 
+golint -set_exit_status $PKGS 
+echo "----------> Running simple"
+gosimple $PKGS 
+echo "----------> Running staticcheck" 
+staticcheck $PKGS 
+echo "----------> Running go test"
+go test -v -cover $PKGS 

--- a/main.go
+++ b/main.go
@@ -69,9 +69,8 @@ func startWatchdog(config types.Configuration) {
 		event := <-healthChan
 		publishToAppInsights(event, config)
 		if config.Debug {
-
+			fmt.Println(prettyPrintStruct(event))
 		}
-		fmt.Println(prettyPrintStruct(event))
 	}
 }
 

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -54,7 +54,7 @@ func (context *RequestContext) makeRequest() types.StatsEvent {
 		SourceTime:      time.Now(),
 		Data:            make(map[string]interface{}),
 		IsSuccess:       false,
-		RequestDuration: time.Now().Sub(context.StartTime),
+		RequestDuration: time.Since(context.StartTime),
 	}
 
 	client := &http.Client{


### PR DESCRIPTION
Builds on the great work of @serbrech 

The docker build will now execute:
- gofmt
- golint
- gosimple (can things be done better?)
- staticcheck (is there unreachable code?)
- go test

On failures you'll see output like 

``` text
 ---> d02944afdce7
Step 8/13 : RUN chmod +x codechecks.sh && ./codechecks.sh
 ---> Running in fedf64293f6c
----------> Running gofmt
----------> Running golint
----------> Running simple
routing/routing.go:57:20: should use time.Since instead of time.Now().Sub (S1012)
```

``` text
Step 8/13 : RUN chmod +x codechecks.sh && ./codechecks.sh
 ---> Running in 5fb770bc4927
----------> Running gofmt
----------> Running golint
----------> Running simple
----------> Running staticcheck
main.go:71:3: empty branch (SA9003)
```