### PR TITLE
Healthcheck credential parameters

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 vendor
 bin
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ traefik-appinsights-watchdog
 debug
 bin
 **/debug.test
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.9.2-alpine
+FROM golang:1.11.4-alpine
 ENV GOBIN /go/bin
 RUN apk add --update --no-progress openssl git wget bash gcc musl-dev && \ 
     rm -rf /var/cache/apk/* && \

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -15,6 +15,11 @@ import (
 	"github.com/lawrencegripper/traefik-appinsights-watchdog/types"
 )
 
+const (
+	testUserName = "sp3cialUs3r"
+	testPassword = "Sup3rSecr3t"
+)
+
 func TestHealthRetreiveMetrics(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(handleHealthSuceed))
 	defer server.Close()
@@ -102,7 +107,7 @@ func TestHealthRetreiveMetrics_Authorized(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	config := types.Configuration{TraefikHealthEndpoint: server.URL + "/health", APIEndpointUsername: "User", APIEndpointPassword: "Sup3rSecr3t"}
+	config := types.Configuration{TraefikHealthEndpoint: server.URL + "/health", APIEndpointUsername: testUserName, APIEndpointPassword: testPassword}
 	channel := make(chan types.StatsEvent)
 
 	go StartCheck(ctx, config, channel)
@@ -215,7 +220,7 @@ func authenticate(r *http.Request) error {
 }
 
 func validate(username, password string) bool {
-	if username == "User" && password == "Sup3rSecr3t" {
+	if username == testUserName && password == testPassword {
 		return true
 	}
 	return false

--- a/types/config.go
+++ b/types/config.go
@@ -11,4 +11,6 @@ type Configuration struct {
 	TraefikHealthEndpoint  string `description:"The traeifk health endpoint http://localhost:port/health"`
 	PollIntervalSec        int    `description:"The time waited between requests to the health endpoint"`
 	AllowInvalidCert       bool   `description:"Allow invalid certificates when performing routing checks on localhost"`
+	APIEndpointUsername    string `description:"Stores username required to call APIs including healthcheck"`
+	APIEndpointPassword    string `description:"Stores password required to call APIs including healthcheck"`
 }


### PR DESCRIPTION
Added 2 optional parameters for username and password to be used whilst calling Traefik's "/health" endpoint.
This is useful when Traefik's API endpoint ("/health" included) is protected with Basic Auth.
